### PR TITLE
Middlewareとして CORS+CSRFToken を追加

### DIFF
--- a/rest-api/controller/user_controller.go
+++ b/rest-api/controller/user_controller.go
@@ -58,7 +58,7 @@ func (uc *userController) LogIn(context echo.Context) error {
 	cookie.Expires = time.Now().Add(24 * time.Hour)
 	cookie.Path = "/"
 	cookie.Domain = os.Getenv("API_DOMAIN")
-	//cookie.Secure = true
+	cookie.Secure = true
 	cookie.HttpOnly = true
 	cookie.SameSite = http.SameSiteNoneMode
 	context.SetCookie(cookie)
@@ -72,7 +72,7 @@ func (uc *userController) LogOut(context echo.Context) error {
 	cookie.Expires = time.Now()
 	cookie.Path = "/"
 	cookie.Domain = os.Getenv("API_DOMAIN")
-	//cookie.Secure = true
+	cookie.Secure = true
 	cookie.HttpOnly = true
 	cookie.SameSite = http.SameSiteNoneMode
 	context.SetCookie(cookie)

--- a/rest-api/controller/user_controller.go
+++ b/rest-api/controller/user_controller.go
@@ -14,6 +14,9 @@ type IUserController interface {
 	SignUp(context echo.Context) error
 	LogIn(context echo.Context) error
 	LogOut(context echo.Context) error
+
+	// middleware
+	CsrfToken(context echo.Context) error
 }
 
 // MARK: - User Controller の実体
@@ -76,3 +79,9 @@ func (uc *userController) LogOut(context echo.Context) error {
 	return context.NoContent(http.StatusOK)
 }
 
+func (uc *userController) CsrfToken(c echo.Context) error {
+	token := c.Get("csrf").(string)
+	return c.JSON(http.StatusOK, echo.Map {
+		"csrf_token": token,
+	})
+}

--- a/rest-api/router/router.go
+++ b/rest-api/router/router.go
@@ -6,10 +6,23 @@ import (
 
 	echojwt "github.com/labstack/echo-jwt/v4"
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 )
 
 func NewRouter(uc controller.IUserController, tc controller.ITaskController) *echo.Echo {
 	e := echo.New()
+
+	// CORS
+	e.Use(middleware.CORSWithConfig(middleware.CORSConfig {
+		AllowOrigins: []string { "http://localhost:3000", os.Getenv("FE_URL") },
+		AllowHeaders: []string { 
+			echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept,
+			echo.HeaderAccessControlAllowHeaders, echo.HeaderXCRFToken 
+		},
+		AllowMethods: []string { "GET", "PUT", "POST", "DELETE" },
+		AllowCredentials: true,
+	}))
+
 	e.POST("/signup", uc.SignUp)
 	e.POST("/login", uc.LogIn)
 	e.POST("/logout", uc.LogOut)

--- a/rest-api/router/router.go
+++ b/rest-api/router/router.go
@@ -16,11 +16,24 @@ func NewRouter(uc controller.IUserController, tc controller.ITaskController) *ec
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig {
 		AllowOrigins: []string { "http://localhost:3000", os.Getenv("FE_URL") },
 		AllowHeaders: []string { 
-			echo.HeaderOrigin, echo.HeaderContentType, echo.HeaderAccept,
-			echo.HeaderAccessControlAllowHeaders, echo.HeaderXCRFToken 
+			echo.HeaderOrigin, 
+			echo.HeaderContentType, 
+			echo.HeaderAccept,
+			echo.HeaderAccessControlAllowHeaders, 
+			echo.HeaderXCRFToken 
 		},
 		AllowMethods: []string { "GET", "PUT", "POST", "DELETE" },
 		AllowCredentials: true,
+	}))
+
+	// CSRF
+	e.Use(middleware.CSRFWithConfig(middleware.CSRFConfig {
+		CookiePath: "/",
+		CookieDomain: os.Getenv("API_DOMAIN"),
+		CookieHTTPOnly: true,   // JavaScriptからCookieをアクセスできないように
+		//CookieSameSite: http.SameSiteNoneMode,
+		CookieSameSite: http.SameSiteDefaultMode,
+		//CookieMaxAge: 60,
 	}))
 
 	e.POST("/signup", uc.SignUp)

--- a/rest-api/router/router.go
+++ b/rest-api/router/router.go
@@ -3,6 +3,7 @@ package router
 import (
 	"os"
 	"go-rest-api/controller"
+	"net/http"
 
 	echojwt "github.com/labstack/echo-jwt/v4"
 	"github.com/labstack/echo/v4"
@@ -20,7 +21,7 @@ func NewRouter(uc controller.IUserController, tc controller.ITaskController) *ec
 			echo.HeaderContentType, 
 			echo.HeaderAccept,
 			echo.HeaderAccessControlAllowHeaders, 
-			echo.HeaderXCRFToken 
+			echo.HeaderXCSRFToken,
 		},
 		AllowMethods: []string { "GET", "PUT", "POST", "DELETE" },
 		AllowCredentials: true,
@@ -35,6 +36,8 @@ func NewRouter(uc controller.IUserController, tc controller.ITaskController) *ec
 		CookieSameSite: http.SameSiteDefaultMode,
 		//CookieMaxAge: 60,
 	}))
+
+	e.GET("/csrf", uc.CsrfToken)
 
 	e.POST("/signup", uc.SignUp)
 	e.POST("/login", uc.LogIn)

--- a/rest-api/router/router.go
+++ b/rest-api/router/router.go
@@ -32,8 +32,8 @@ func NewRouter(uc controller.IUserController, tc controller.ITaskController) *ec
 		CookiePath: "/",
 		CookieDomain: os.Getenv("API_DOMAIN"),
 		CookieHTTPOnly: true,   // JavaScriptからCookieをアクセスできないように
-		//CookieSameSite: http.SameSiteNoneMode,
-		CookieSameSite: http.SameSiteDefaultMode,
+		CookieSameSite: http.SameSiteNoneMode,
+		//CookieSameSite: http.SameSiteDefaultMode,
 		//CookieMaxAge: 60,
 	}))
 


### PR DESCRIPTION
# 確認方法

`postman` を使用して確認します。

## ログイン失敗を確認

**リクエスト**

`POST` : `http://localhost:8080/login`
```
{
    "email": "user01@example.com",
    "password": "pass01"
}
```

**レスポンス**
CSRFトークンを付与しないと失敗することを確認

```
{
    "message": "missing csrf token in request header"
}
```


## CSRFトークンを発行

**リクエスト**
`GET` : `http://localhost:8080/csrf`

リクエスト後、header を確認すると`cookie` に `_csrf=〜` としてCSRFトークンが保存される。

## 再度ログイン

※ CSRFトークンを付与した状態でないとログインできない

**header に CSRFトークン を付与する**
Key : `X-CSRF-TOKEN`
Value : `取得したCSRFトークン`

**リクエスト**
`POST` : `http://localhost:8080/login`
```
{
    "email": "user01@example.com",
    "password": "pass01"
}
```

